### PR TITLE
Add Waitly job Terraform

### DIFF
--- a/.github/workflows/split-deploy-terraform.yaml
+++ b/.github/workflows/split-deploy-terraform.yaml
@@ -1,0 +1,91 @@
+name: Terragrunt Deploy to AWS
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to append to resource names'
+        required: true
+        default: 'cicdexec'
+      environment:
+        description: 'Deployment environment (dev or prod)'
+        required: true
+        default: 'dev'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-east-1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Install Terragrunt
+        run: |
+          TG_VERSION=v0.55.1
+          curl -L -o terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/${TG_VERSION}/terragrunt_linux_amd64
+          chmod +x terragrunt
+          sudo mv terragrunt /usr/local/bin/terragrunt
+
+      - name: Set environment variables
+        run: |
+          if [[ "${{ github.event.inputs.environment }}" == "prod" ]]; then
+            ENV_FILE="env/env.prod"
+            echo "ENVIRONMENT=prod" >> $GITHUB_ENV
+            echo "AWS_ACCESS_KEY_ID=${{ secrets.TDP_AWS_ACCESS_KEY_PROD }}" >> $GITHUB_ENV
+            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.TDP_AWS_SECRET_ACCESS_KEY_PROD }}" >> $GITHUB_ENV
+          else
+            ENV_FILE="env/env.dev"
+            echo "ENVIRONMENT=dev" >> $GITHUB_ENV
+            echo "AWS_ACCESS_KEY_ID=${{ secrets.TDP_AWS_ACCESS_KEY_DEV }}" >> $GITHUB_ENV
+            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.TDP_AWS_SECRET_ACCESS_KEY_DEV }}" >> $GITHUB_ENV
+          fi
+
+          echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
+          cat "$ENV_FILE" >> $GITHUB_ENV
+
+          while IFS= read -r line || [ -n "$line" ]; do
+            [[ "$line" == "" || "$line" =~ ^# ]] && continue
+            key=${line%%=*}
+            value=${line#*=}
+            lower=$(echo "$key" | tr '[:upper:]' '[:lower:]')
+            echo "TF_VAR_${lower}=${value}" >> $GITHUB_ENV
+          done < "$ENV_FILE"
+
+          echo "TF_VAR_tag=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          echo "TF_VAR_environment=${{ github.event.inputs.environment }}" >> $GITHUB_ENV
+
+      - name: Prepare DAT Utilities Lambda layer
+        run: |
+          mkdir -p dat_layer_build/python
+          cp -r dat_utilities dat_layer_build/python/
+          touch dat_layer_build/python/__init__.py
+          touch dat_layer_build/python/dat_utilities/__init__.py
+          cd dat_layer_build && zip -r ../dat_utilities.zip .
+          echo "TF_VAR_dat_utilities_zip=$(pwd)/../dat_utilities.zip" >> $GITHUB_ENV
+          cd ..
+
+      - name: Package Waitly Lambda function
+        run: |
+          mkdir -p waitly_build
+          cp jobs/waitly/store-summary/lambda_functions/waitly-live-api-daily/waitly-live-api-daily.py waitly_build/
+          cd waitly_build && zip -r ../waitly-live-api-daily.zip .
+          echo "TF_VAR_waitly_live_zip=$(pwd)/../waitly-live-api-daily.zip" >> $GITHUB_ENV
+          cd ..
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terragrunt Init
+        run: terragrunt init
+
+      - name: Terragrunt Apply
+        run: terragrunt apply -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
 __pycache__/
 venv/
 templates/.DS_Store
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+
+.terragrunt-cache/
+# Lambda build artifacts
+waitly-live-api-daily.zip
+dat_utilities.zip

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,160 @@
+resource "aws_iam_role" "glue_job_role" {
+  name = "GlueRole-${var.tag}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = ["glue.amazonaws.com", "lambda.amazonaws.com"] }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole",
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/SecretsManagerReadWrite",
+  ]
+
+  inline_policy {
+    name   = "GluePolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = ["s3:*"]
+          Resource = [
+            "arn:aws:s3:::${var.glue_assets_bucket_name}*",
+            "arn:aws:s3:::${var.source_bucket_name}*"
+          ]
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["glue:*"]
+          Resource = "*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["secretsmanager:*"]
+          Resource = "*"
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name = "LambdaRole-${var.tag}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  inline_policy {
+    name   = "LambdaRole"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = ["s3:*", "secretsmanager:*"]
+          Resource = "*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["dynamodb:*"]
+          Resource = "*"
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_iam_role" "state_machine_execution_role" {
+  name = "StateMachineExecutionRole-${var.tag}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = ["states.amazonaws.com", "lambda.amazonaws.com"] }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess",
+    "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  ]
+
+  inline_policy {
+    name   = "StepFunctionPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = ["glue:StartJobRun", "glue:GetJobRun", "glue:GetJobRuns", "glue:BatchStopJobRun"]
+        Resource = "*"
+      }]
+    })
+  }
+}
+
+resource "aws_iam_role" "comprehensive_role" {
+  name = "ComprehensiveRole-${var.tag}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = [
+        "states.amazonaws.com",
+        "glue.amazonaws.com",
+        "lambda.amazonaws.com",
+        "dynamodb.amazonaws.com",
+        "scheduler.amazonaws.com"
+      ] }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess",
+    "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole",
+    "arn:aws:iam::aws:policy/AWSLambda_FullAccess",
+    "arn:aws:iam::aws:policy/AdministratorAccess"
+  ]
+
+  inline_policy {
+    name   = "ComprehensiveRolePolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = [
+            "glue:*", "s3:*", "rds:*", "ec2:*", "redshift:*", "lambda:*",
+            "logs:*", "states:*", "events:*", "athena:*", "secretsmanager:*",
+            "ses:*", "kinesis:*", "sqs:*", "firehose:*", "dynamodb:*",
+            "cloudwatch:*", "databrew:*", "aws-marketplace:*"
+          ]
+          Resource = "*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = "lambda:InvokeFunction"
+          Resource = "arn:aws:lambda:*:${data.aws_caller_identity.current.account_id}:function/*"
+        }
+      ]
+    })
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/lambda_layer.tf
+++ b/terraform/lambda_layer.tf
@@ -1,0 +1,11 @@
+resource "aws_lambda_layer_version" "dat_utilities" {
+  filename          = var.dat_utilities_zip
+  layer_name        = "dat-utilities-layer-${var.tag}"
+  compatible_runtimes = ["python3.9"]
+}
+
+variable "dat_utilities_zip" {
+  description = "Path to the zipped dat utilities layer"
+  type        = string
+  default     = "../dat_layer_build/dat_utilities.zip"
+}

--- a/terraform/modules/waitly/main.tf
+++ b/terraform/modules/waitly/main.tf
@@ -1,0 +1,40 @@
+resource "aws_lambda_function" "waitly_live" {
+  function_name = "waitly-live-api-daily-${var.tag}"
+  handler       = "waitly-live-api-daily.lambda_handler"
+  runtime       = "python3.9"
+  role          = var.lambda_role_arn
+
+  filename         = var.waitly_live_zip
+  source_code_hash = filebase64sha256(var.waitly_live_zip)
+
+  timeout     = 180
+  memory_size = 128
+  architectures = ["x86_64"]
+
+  environment {
+    variables = {
+      LOG_LEVEL     = "INFO"
+      BRONZE_BUCKET = var.bronze_bucket
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "waitly_live" {
+  name                = "waitlylive-${var.tag}"
+  schedule_expression = "rate(1 day)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_target" "waitly_live" {
+  rule      = aws_cloudwatch_event_rule.waitly_live.name
+  target_id = "WaitlyLiveLambdaTarget"
+  arn       = aws_lambda_function.waitly_live.arn
+}
+
+resource "aws_lambda_permission" "allow_eventbridge_waitly_live" {
+  statement_id  = "AllowExecutionFromCloudWatchEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.waitly_live.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.waitly_live.arn
+}

--- a/terraform/modules/waitly/outputs.tf
+++ b/terraform/modules/waitly/outputs.tf
@@ -1,0 +1,3 @@
+output "waitly_live_lambda_arn" {
+  value = aws_lambda_function.waitly_live.arn
+}

--- a/terraform/modules/waitly/variables.tf
+++ b/terraform/modules/waitly/variables.tf
@@ -1,0 +1,19 @@
+variable "tag" {
+  description = "Deployment tag appended to resource names"
+  type        = string
+}
+
+variable "bronze_bucket" {
+  description = "Bronze bucket used by the lambda"
+  type        = string
+}
+
+variable "waitly_live_zip" {
+  description = "Path to the zipped waitly live lambda code"
+  type        = string
+}
+
+variable "lambda_role_arn" {
+  description = "IAM role ARN for the Waitly lambda"
+  type        = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "glue_job_role_arn" {
+  value = aws_iam_role.glue_job_role.arn
+}
+
+output "lambda_role_arn" {
+  value = aws_iam_role.lambda_role.arn
+}
+
+output "comprehensive_role_arn" {
+  value = aws_iam_role.comprehensive_role.arn
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "tag" {
+  description = "Deployment tag appended to resource names"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev or prod)"
+  type        = string
+}
+
+variable "source_bucket_name" {
+  description = "Bucket used to store the repo"
+  type        = string
+}
+
+variable "glue_assets_bucket_name" {
+  description = "Bucket for glue runtime logs"
+  type        = string
+}
+
+variable "saphana_glue_connection" {
+  description = "Name of the SAP HANA Glue connection"
+  type        = string
+}
+
+variable "bronze_bucket" { type = string }
+variable "silver_bucket" { type = string }
+variable "gold_bucket"   { type = string }
+variable "finance_bucket" { type = string }
+variable "repsly_bucket" { type = string }
+variable "repsly_dynamo_table" { type = string }
+variable "tdp_sf_db" { type = string }
+variable "sap_hana_layer" { type = string }
+variable "snowflake_layer" { type = string }
+variable "waitly_live_zip" {
+  description = "Path to the zipped waitly live lambda code"
+  type        = string
+  default     = "../waitly-live-api-daily.zip"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/waitly.tf
+++ b/terraform/waitly.tf
@@ -1,0 +1,8 @@
+module "waitly" {
+  source = "./modules/waitly"
+
+  tag            = var.tag
+  bronze_bucket  = var.bronze_bucket
+  waitly_live_zip = var.waitly_live_zip
+  lambda_role_arn = aws_iam_role.lambda_role.arn
+}

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -1,0 +1,23 @@
+terraform {
+  source = "./terraform"
+}
+
+inputs = {
+  aws_region             = "us-east-1"
+  tag                    = getenv("TF_VAR_tag", "cicdexec")
+  environment            = getenv("TF_VAR_environment", "dev")
+  source_bucket_name     = getenv("TF_VAR_source_bucket_name", "")
+  glue_assets_bucket_name = getenv("TF_VAR_glue_assets_bucket_name", "")
+  saphana_glue_connection = getenv("TF_VAR_saphana_glue_connection", "")
+  bronze_bucket          = getenv("TF_VAR_bronze_bucket", "")
+  silver_bucket          = getenv("TF_VAR_silver_bucket", "")
+  gold_bucket            = getenv("TF_VAR_gold_bucket", "")
+  finance_bucket         = getenv("TF_VAR_finance_bucket", "")
+  repsly_bucket          = getenv("TF_VAR_repsly_bucket", "")
+  repsly_dynamo_table    = getenv("TF_VAR_repsly_dynamo_table", "")
+  tdp_sf_db              = getenv("TF_VAR_tdp_sf_db", "")
+  sap_hana_layer         = getenv("TF_VAR_sap_hana_layer", "")
+  snowflake_layer        = getenv("TF_VAR_snowflake_layer", "")
+  dat_utilities_zip      = getenv("TF_VAR_dat_utilities_zip", "../dat_utilities.zip")
+  waitly_live_zip        = getenv("TF_VAR_waitly_live_zip", "../waitly-live-api-daily.zip")
+}


### PR DESCRIPTION
## Summary
- package Waitly lambda in deploy workflow
- ignore lambda build artifacts
- wrap Waitly job in Terraform
- pass Waitly lambda zip through Terragrunt
- refactor Waitly resources into a Terraform module
- automatically map env.dev/env.prod values to TF_VAR_* for Terragrunt

## Testing
- `pre-commit run --files .github/workflows/split-deploy-terraform.yaml terragrunt.hcl terraform/waitly.tf terraform/variables.tf terraform/modules/waitly/main.tf terraform/modules/waitly/variables.tf terraform/modules/waitly/outputs.tf .gitignore` *(fails: command not found)*
- `terraform init -backend=false` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6851cc83bef883279f195cda1bc4782a